### PR TITLE
Utilisation de to_int(admin_level) à la place de admin_level::integer

### DIFF
--- a/database/layers_query.sql
+++ b/database/layers_query.sql
@@ -278,7 +278,7 @@ ORDER BY layer ASC, render ASC
 -- admin_boundaries
 SELECT
   ST_Simplify(b.way,!pixel_width!/4) as way,
-  admin_level::integer AS admin_level,
+  to_int(admin_level) AS admin_level,
   coalesce(b.tags->'maritime','no') AS maritime,
   count(r.*)::integer AS nb,
   string_agg(id::text,',') AS rels


### PR DESCRIPTION
Ceci évite une erreur à l'exécution de la requête lorsque le tag admin_level ne contient pas un nombre entier.