### PR TITLE
utiliser planet_osm_roads pour les label des motorway/trunk

### DIFF
--- a/database/layers_query.sql
+++ b/database/layers_query.sql
@@ -323,7 +323,7 @@ SELECT
   CHAR_LENGTH(ref) AS reflen,
   way
 FROM
-  planet_osm_line
+  planet_osm_roads
 WHERE
   highway IN ('motorway', 'trunk')
   AND (COALESCE(tags -> 'name:br'::text,'') IS NOT NULL OR ref IS NOT NULL)


### PR DESCRIPTION
planet_osm_roads contient tous les motorway/trunk

la requête est environ 10x plus rapide.