### PR TITLE
utiliser planet_osm_roads pour la couche roads_low

### DIFF
--- a/database/layers_query.sql
+++ b/database/layers_query.sql
@@ -133,10 +133,10 @@ SELECT
       WHEN railway IN ('rail') THEN 'railway'
   ELSE 'other'
   END AS stylegroup 
-FROM planet_osm_line 
+FROM planet_osm_roads
 WHERE
-  highway IN ('motorway', 'trunk', 'primary')
-  OR railway IN ('rail')
+  (highway IN ('motorway', 'trunk', 'primary')
+    OR railway IN ('rail'))
   AND (tunnel IS NULL OR tunnel = 'no') 
   AND (bridge IS NULL OR bridge = 'no') 
 ORDER BY z_order


### PR DESCRIPTION
10x plus rapide et même résultat

Manquait aussi des parenthèses pour le OR.